### PR TITLE
Update mini_sendmail.c

### DIFF
--- a/mini_sendmail.c
+++ b/mini_sendmail.c
@@ -389,7 +389,7 @@ make_received( char* from, char* username, char* hostname )
 
     t = time( (time_t*) 0 );
     tmP = localtime( &t );
-    (void) strftime( timestamp, sizeof(timestamp), "%a, %d %b %Y %T %Z", tmP );
+    (void) strftime( timestamp, sizeof(timestamp), "%a, %d %b %Y %H:%M:%S %Z", tmP );
     received_size =
 	500 + strlen( from ) + strlen( hostname ) * 2 + strlen( MINI_SENDMAIL_VERSION ) +
 	strlen( timestamp ) + strlen( username );


### PR DESCRIPTION
'%T' isn't in `-ansi` C (c90) under gcc.  (It's in c99.)  Replaced with long version.