### PR TITLE
parse_for_recipients: stop at `\r` or `\n`

### DIFF
--- a/mini_sendmail.c
+++ b/mini_sendmail.c
@@ -548,6 +548,7 @@ parse_for_recipients( char* message )
 	    case ST_RECIPS:
 	    switch ( *cp )
 		{
+		case '\r':
 		case '\n':
 		add_recipient( recip, ( cp - recip ) );
 		state = ST_BOL;
@@ -558,6 +559,7 @@ parse_for_recipients( char* message )
 		    cp = bcc - 1;
 		    bcc = (char*) 0;
 		    }
+		if (*cp == '\r') ++cp;
 		break;
 		case ',':
 		add_recipient( recip, ( cp - recip ) );


### PR DESCRIPTION
When `mini_sendmail -t` receives on standard input `To: ab@domai.nn\r\n` it parses the recipient as `ab@domai.nn\r` and handles this to sendmail, as

[pid 3071785] write(6, "RCPT TO:<at@domai.nn\r>\r\n", 24) = 24

Then sendmail inserts header
```
Received: from …
    for <at@domain.nn^M>; Thu, 7 Dec 2023 21:18:21 GMT
```
where `^M` is `\r` (new line).  The LMTP rejects the email with the statement that `>;` is invalid header.

This changeset skips the `\r` (before `\n`) when parsing `To:` headers.